### PR TITLE
fix the link invalid in after hydrate

### DIFF
--- a/arkhi/client/client.tsx
+++ b/arkhi/client/client.tsx
@@ -54,10 +54,26 @@ const explore = (parentNode: Node) => {
 			continue;
 		}
 
+		
+		const newAttr: { [key: string]: string } = {}; 
+		// Iterate through attributes and populate the attributes namedNodeMap
+		for (let i = 0; i < attributes.length; i++) {
+			const attribute = attributes.item(i);
+			if (attribute) {
+				const reactAttributeName = attribute.name
+					.replace(/[-:]/g, '') // Remove hyphens and colons
+					.replace(/class/g, 'className') // Convert 'class' to 'className'
+					.replace(/for/g, 'htmlFor'); // Convert 'for' to 'htmlFor'
+
+				newAttr[reactAttributeName] = attribute.value;
+			}
+		}
+
+
 		const childTree = explore(currentNode);
 		const component = React.createElement(
 			currentNode.nodeName.toLowerCase(),
-			attributes,
+			newAttr,
 			childTree
 		);
 


### PR DESCRIPTION
島嶼同個 parent 下的 link 會在 hydrate 時失效  #22 
原因: 在重新建構React Element 時直接使用透過 (Node as Element).attributes獲得的namedNodeMap，React.createElement並不能直接使用該結構