### PR TITLE
feat(build): keep name in esbuild

### DIFF
--- a/arkhi/client/client.tsx
+++ b/arkhi/client/client.tsx
@@ -107,5 +107,6 @@ const walk = (node: Node | null) => {
 
 export function renderIslands(node: Node) {
 	propsMap = superjson.parse(window.propString || "{}");
+	console.log(IslandMap);
 	walk(node);
 }

--- a/arkhi/client/client.tsx
+++ b/arkhi/client/client.tsx
@@ -107,6 +107,5 @@ const walk = (node: Node | null) => {
 
 export function renderIslands(node: Node) {
 	propsMap = superjson.parse(window.propString || "{}");
-	console.log(IslandMap);
 	walk(node);
 }

--- a/arkhi/client/island.tsx
+++ b/arkhi/client/island.tsx
@@ -1,22 +1,27 @@
 import React, { FunctionComponent } from "react";
-import { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 export type IslandProps = { _island_id?: string };
 
 export const IslandMap = new Map<string, ComponentType<any>>();
 export const IslandProps = new Map<string, Object>();
 
+/**
+ * Generates an island component that can be hydrated on the frontend.
+ * @param Component React Component to convert into a island component.
+ * @param prefix Optional prefix in case there is a name conflict
+ * @returns Island component
+ */
 export function Island<T extends object>(
-	namespace: string,
-	Component: FunctionComponent<T & IslandProps> | FunctionComponent<T>
+	Component: FunctionComponent<T & IslandProps> | FunctionComponent<T>,
+	prefix: string = ""
 ): FunctionComponent<T & IslandProps> | FunctionComponent<T> {
-	const islandID = hash(`${namespace}${Component.name}`);
+	const islandID = `${prefix}${Component.name}`;
 	IslandMap.set(islandID, Component);
 
 	const NewComponent: ComponentType<T & IslandProps> = (props: T) => {
 		const propsID = hash(`${islandID}${JSON.stringify(props)}`);
 		IslandProps.set(propsID, props);
-		// TODO create prop map
 		return <Component {...props} _island_id={`${islandID}:${propsID}`} />;
 	};
 

--- a/arkhi/plugins/arkhi-plugin.ts
+++ b/arkhi/plugins/arkhi-plugin.ts
@@ -1,6 +1,7 @@
 import { Plugin } from "vite";
 import arkhiCMS from "./cms";
+import optimizeBuildSettings from "./build-config";
 
 export function arkhiPlugin(): Plugin[] {
-	return [arkhiCMS()];
+	return [arkhiCMS(), optimizeBuildSettings()];
 }

--- a/arkhi/plugins/build-config.ts
+++ b/arkhi/plugins/build-config.ts
@@ -1,39 +1,16 @@
-import { Plugin } from 'vite';
+import { Plugin } from "vite";
 export default function optimizeBuildSettings(): Plugin {
-    return {
-        name: 'arkhi-build-settings',
-        config(config) {
-            if (!config.build) {
-                config.build = {};
-            }
-            if (!config.esbuild) {
-                config.esbuild = {};
-            }
-            if (!config.build.rollupOptions) {
-                config.build.rollupOptions = {};
-            }
-            config.build.emptyOutDir = true;
-            config.build.copyPublicDir = true;
-            config.build.modulePreload = true;
-            config.build.minify = 'esbuild';
-            config.build.manifest = true;
-            config.build.ssr = true;
-            config.build.ssrManifest = true;
-            config.build.ssrEmitAssets = true;
+	return {
+		name: "arkhi-build-settings",
+		config(config) {
+			if (!config.esbuild) {
+				config.esbuild = {};
+			}
 
-            config.esbuild.minifyIdentifiers = true;
-            config.esbuild.keepNames = true;
+			config.esbuild.minifyIdentifiers = true;
+			config.esbuild.keepNames = true;
 
-            config.build.rollupOptions.preserveEntrySignatures = 'strict'
-
-            config.build.rollupOptions.output = {
-                compact: true,
-            };
-            config.build.rollupOptions.output.generatedCode = {
-                constBindings: true,
-                objectShorthand: true,
-            };
-            return config;
-        },
-    }
+			return config;
+		},
+	};
 }

--- a/arkhi/plugins/build-config.ts
+++ b/arkhi/plugins/build-config.ts
@@ -1,0 +1,39 @@
+import { Plugin } from 'vite';
+export default function optimizeBuildSettings(): Plugin {
+    return {
+        name: 'arkhi-build-settings',
+        config(config) {
+            if (!config.build) {
+                config.build = {};
+            }
+            if (!config.esbuild) {
+                config.esbuild = {};
+            }
+            if (!config.build.rollupOptions) {
+                config.build.rollupOptions = {};
+            }
+            config.build.emptyOutDir = true;
+            config.build.copyPublicDir = true;
+            config.build.modulePreload = true;
+            config.build.minify = 'esbuild';
+            config.build.manifest = true;
+            config.build.ssr = true;
+            config.build.ssrManifest = true;
+            config.build.ssrEmitAssets = true;
+
+            config.esbuild.minifyIdentifiers = true;
+            config.esbuild.keepNames = true;
+
+            config.build.rollupOptions.preserveEntrySignatures = 'strict'
+
+            config.build.rollupOptions.output = {
+                compact: true,
+            };
+            config.build.rollupOptions.output.generatedCode = {
+                constBindings: true,
+                objectShorthand: true,
+            };
+            return config;
+        },
+    }
+}

--- a/pages/about/Component.tsx
+++ b/pages/about/Component.tsx
@@ -14,7 +14,7 @@ function Accumulator_({ ...props }) {
 	);
 }
 
-const Accumulator = Island("Component", Accumulator_);
+const Accumulator = Island(Accumulator_);
 export default Accumulator;
 
 function Adder_({ ...props }) {
@@ -25,7 +25,7 @@ function Adder_({ ...props }) {
 		</button>
 	);
 }
-export const Adder = Island("Component", Adder_);
+export const Adder = Island(Adder_);
 
 function Counter_({ temp, ...props }: { temp?: string }) {
 	const [count, setCount] = useState(0);
@@ -40,7 +40,7 @@ function Counter_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const Counter = Island("Component", Counter_);
+export const Counter = Island(Counter_);
 
 function CountNumber_({ temp, ...props }: { temp?: string }) {
 	const [count, setCount] = useState(0);
@@ -55,7 +55,7 @@ function CountNumber_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const CountNumber = Island("Component", CountNumber_);
+export const CountNumber = Island(CountNumber_);
 
 function TextDisplay_({ temp, ...props }: { temp?: string }) {
 	const [text, setText] = useState("Initial text");
@@ -66,7 +66,7 @@ function TextDisplay_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const TextDisplay = Island("Component", TextDisplay_);
+export const TextDisplay = Island(TextDisplay_);
 
 function ReverseCounter_({ temp, ...props }: { temp?: string }) {
 	const [count, setCount] = useState(10);
@@ -81,7 +81,7 @@ function ReverseCounter_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const ReverseCounter = Island("Component", ReverseCounter_);
+export const ReverseCounter = Island(ReverseCounter_);
 
 // Toggle Component
 function Toggle_({ temp, ...props }: { temp?: string }) {
@@ -93,7 +93,7 @@ function Toggle_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const Toggle = Island("Component", Toggle_);
+export const Toggle = Island(Toggle_);
 
 // DoubleCounter Component
 function DoubleCounter_({ temp, ...props }: { temp?: string }) {
@@ -109,7 +109,7 @@ function DoubleCounter_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const DoubleCounter = Island("Component", DoubleCounter_);
+export const DoubleCounter = Island(DoubleCounter_);
 
 // TripleCounter Component
 function TripleCounter_({ temp, ...props }: { temp?: string }) {
@@ -125,7 +125,7 @@ function TripleCounter_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const TripleCounter = Island("Component", TripleCounter_);
+export const TripleCounter = Island(TripleCounter_);
 
 // ColorChanger Component
 function ColorChanger_({ temp, ...props }: { temp?: string }) {
@@ -142,7 +142,7 @@ function ColorChanger_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const ColorChanger = Island("Component", ColorChanger_);
+export const ColorChanger = Island(ColorChanger_);
 
 // RandomColorChanger Component
 function RandomColorChanger_({ temp, ...props }: { temp?: string }) {
@@ -159,7 +159,7 @@ function RandomColorChanger_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const RandomColorChanger = Island("Component", RandomColorChanger_);
+export const RandomColorChanger = Island(RandomColorChanger_);
 
 // CounterDoubler Component
 function CounterDoubler_({ temp, ...props }: { temp?: string }) {
@@ -171,7 +171,7 @@ function CounterDoubler_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const CounterDoubler = Island("Component", CounterDoubler_);
+export const CounterDoubler = Island(CounterDoubler_);
 
 // VolumeController Component
 function VolumeController_({ temp, ...props }: { temp?: string }) {
@@ -190,7 +190,7 @@ function VolumeController_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const VolumeController = Island("Component", VolumeController_);
+export const VolumeController = Island(VolumeController_);
 
 // DatePicker Component
 function DatePicker_({ temp, ...props }: { temp?: string }) {
@@ -207,7 +207,7 @@ function DatePicker_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const DatePicker = Island("Component", DatePicker_);
+export const DatePicker = Island(DatePicker_);
 
 // TodoList Component
 function TodoList_({ temp, ...props }: { temp?: string }) {
@@ -250,7 +250,7 @@ function TodoList_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const TodoList = Island("Component", TodoList_);
+export const TodoList = Island(TodoList_);
 
 // Switch Component
 function Switch_({ temp, ...props }: { temp?: string }) {
@@ -262,7 +262,7 @@ function Switch_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const Switch = Island("Component", Switch_);
+export const Switch = Island(Switch_);
 
 // TextChanger Component
 function TextChanger_({ temp, ...props }: { temp?: string }) {
@@ -279,7 +279,7 @@ function TextChanger_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const TextChanger = Island("Component", TextChanger_);
+export const TextChanger = Island(TextChanger_);
 
 // ProgressBar Component
 function ProgressBar_({ temp, ...props }: { temp?: string }) {
@@ -298,7 +298,7 @@ function ProgressBar_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const ProgressBar = Island("Component", ProgressBar_);
+export const ProgressBar = Island(ProgressBar_);
 
 // Multiplier Component
 function Multiplier_({ temp, ...props }: { temp?: string }) {
@@ -310,7 +310,7 @@ function Multiplier_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const Multiplier = Island("Component", Multiplier_);
+export const Multiplier = Island(Multiplier_);
 
 // Divisor Component
 function Divisor_({ temp, ...props }: { temp?: string }) {
@@ -322,7 +322,7 @@ function Divisor_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const Divisor = Island("Component", Divisor_);
+export const Divisor = Island(Divisor_);
 
 // NoteMaker Component
 function NoteMaker_({ temp, ...props }: { temp?: string }) {
@@ -352,7 +352,7 @@ function NoteMaker_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const NoteMaker = Island("Component", NoteMaker_);
+export const NoteMaker = Island(NoteMaker_);
 
 // BrightnessController Component
 function BrightnessController_({ temp, ...props }: { temp?: string }) {
@@ -371,7 +371,7 @@ function BrightnessController_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const BrightnessController = Island("Component", BrightnessController_);
+export const BrightnessController = Island(BrightnessController_);
 
 // FontSizeController Component
 function FontSizeController_({ temp, ...props }: { temp?: string }) {
@@ -390,7 +390,7 @@ function FontSizeController_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const FontSizeController = Island("Component", FontSizeController_);
+export const FontSizeController = Island(FontSizeController_);
 
 // Stopwatch Component
 function Stopwatch_({ temp, ...props }: { temp?: string }) {
@@ -422,7 +422,7 @@ function Stopwatch_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const Stopwatch = Island("Component", Stopwatch_);
+export const Stopwatch = Island(Stopwatch_);
 
 // Currency Converter Component
 function CurrencyConverter_({ temp, ...props }: { temp?: string }) {
@@ -445,7 +445,7 @@ function CurrencyConverter_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const CurrencyConverter = Island("Component", CurrencyConverter_);
+export const CurrencyConverter = Island(CurrencyConverter_);
 
 // TextMirror Component
 function TextMirror_({ temp, ...props }: { temp?: string }) {
@@ -463,7 +463,7 @@ function TextMirror_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const TextMirror = Island("Component", TextMirror_);
+export const TextMirror = Island(TextMirror_);
 
 // TemperatureConverter Component
 function TemperatureConverter_({ temp, ...props }: { temp?: string }) {
@@ -485,7 +485,7 @@ function TemperatureConverter_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const TemperatureConverter = Island("Component", TemperatureConverter_);
+export const TemperatureConverter = Island(TemperatureConverter_);
 
 // PasswordGenerator Component
 function PasswordGenerator_({ temp, ...props }: { temp?: string }) {
@@ -510,4 +510,4 @@ function PasswordGenerator_({ temp, ...props }: { temp?: string }) {
 	);
 }
 
-export const PasswordGenerator = Island("Component", PasswordGenerator_);
+export const PasswordGenerator = Island(PasswordGenerator_);

--- a/pages/about/DocSorter.tsx
+++ b/pages/about/DocSorter.tsx
@@ -1,105 +1,119 @@
 import React, { ReactElement, useEffect, useState } from "react";
 import { Island } from "@/arkhi/client";
 
-import MDXContent, { metadata as mdxMetadata } from '../../content/index.md'
-import Post02, { metadata as post02Metadata } from "../../content/article/post02.md";
+import MDXContent, { metadata as mdxMetadata } from "../../content/index.md";
+import Post02, {
+	metadata as post02Metadata,
+} from "../../content/article/post02.md";
 import Games, { metadata as gamesMetadata } from "../../content/games.mdx";
-import Test, { metadata as testMetadata } from '../../content/test.md'
+import Test, { metadata as testMetadata } from "../../content/test.md";
 
 interface ArticleMetadataProps {
-    title: string;
-    author: string;
-    views: number;
-    lastAccessed: Date;
+	title: string;
+	author: string;
+	views: number;
+	lastAccessed: Date;
 }
 
-function ArticleMetadata({ title, author, views, lastAccessed }: ArticleMetadataProps) {
-    return (
-        <div className="metadata">
-            <h4 className="title">{title}</h4>
-            <p className="author">By {author}</p>
-            <p className="views">{views} Views</p>
-            <p className="lastAccessed">Last Accessed: {lastAccessed.toLocaleString()}</p>
-        </div>
-    );
+function ArticleMetadata({
+	title,
+	author,
+	views,
+	lastAccessed,
+}: ArticleMetadataProps) {
+	return (
+		<div className="metadata">
+			<h4 className="title">{title}</h4>
+			<p className="author">By {author}</p>
+			<p className="views">{views} Views</p>
+			<p className="lastAccessed">
+				Last Accessed: {lastAccessed.toLocaleString()}
+			</p>
+		</div>
+	);
 }
 
 function renderMarkdownFile(filePath: string | string[]) {
-    if (filePath.includes("index.md")) {
-        return <MDXContent />;
-    } else if (filePath.includes("post02.md")) {
-        return <Post02 />;
-    } else if (filePath.includes("games.mdx")) {
-        return <Games />;
-    } else if (filePath.includes('test.md')) {
-        return <Test />;
-    }
+	if (filePath.includes("index.md")) {
+		return <MDXContent />;
+	} else if (filePath.includes("post02.md")) {
+		return <Post02 />;
+	} else if (filePath.includes("games.mdx")) {
+		return <Games />;
+	} else if (filePath.includes("test.md")) {
+		return <Test />;
+	}
 }
 
 function DocSorter_({ ...props }) {
-    const metadataArray = [mdxMetadata, post02Metadata, gamesMetadata, testMetadata];
-    const [isDescending, setIsDescending] = useState(false);
-    const [renderedContent, setRenderedContent] = useState<ReactElement[]>([]);
+	const metadataArray = [
+		mdxMetadata,
+		post02Metadata,
+		gamesMetadata,
+		testMetadata,
+	];
+	const [isDescending, setIsDescending] = useState(false);
+	const [renderedContent, setRenderedContent] = useState<ReactElement[]>([]);
 
-    useEffect(() => {
-        updateRenderedContent();
-    }, [isDescending]);
+	useEffect(() => {
+		updateRenderedContent();
+	}, [isDescending]);
 
-    const handleSortToggle = () => {
-        setIsDescending(!isDescending);
-    };
+	const handleSortToggle = () => {
+		setIsDescending(!isDescending);
+	};
 
-    function Card({ metadata }: { metadata: any }) {
-        const [showContent, setShowContent] = useState(false);
-        const handleMouseEnter = () => {
-            setShowContent(true);
-        };
-        const handleMouseLeave = () => {
-            setShowContent(false);
-        };
+	function Card({ metadata }: { metadata: any }) {
+		const [showContent, setShowContent] = useState(false);
+		const handleMouseEnter = () => {
+			setShowContent(true);
+		};
+		const handleMouseLeave = () => {
+			setShowContent(false);
+		};
 
-        return (
-            <div
-                className="card"
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
-            >
-                <ArticleMetadata
-                    title={metadata.title}
-                    author={metadata.author}
-                    views={metadata.views}
-                    lastAccessed={new Date(metadata.atime)}
-                />
-                {showContent && renderMarkdownFile(metadata.filePath)}
-            </div>
-        );
-    }
+		return (
+			<div
+				className="card"
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+			>
+				<ArticleMetadata
+					title={metadata.title}
+					author={metadata.author}
+					views={metadata.views}
+					lastAccessed={new Date(metadata.atime)}
+				/>
+				{showContent && renderMarkdownFile(metadata.filePath)}
+			</div>
+		);
+	}
 
-    function updateRenderedContent() {
-        const sortedMetadataArray = [...metadataArray].sort((a, b) =>
-            isDescending
-                ? new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-                : new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-        );
-        const newRenderedContent = sortedMetadataArray.map((metadata) => (
-            <Card metadata={metadata} key={metadata.title} />
-        ));
-        setRenderedContent(newRenderedContent);
-    }
+	function updateRenderedContent() {
+		const sortedMetadataArray = [...metadataArray].sort((a, b) =>
+			isDescending
+				? new Date(b.createdAt).getTime() -
+				  new Date(a.createdAt).getTime()
+				: new Date(a.createdAt).getTime() -
+				  new Date(b.createdAt).getTime()
+		);
+		const newRenderedContent = sortedMetadataArray.map((metadata) => (
+			<Card metadata={metadata} key={metadata.title} />
+		));
+		setRenderedContent(newRenderedContent);
+	}
 
-    return (
-        <div>
-            <button type="button" onClick={handleSortToggle} {...props}>
-                {isDescending ? "Sort Descending" : "Sort Ascending"}
-            </button>
-            {renderedContent.map((content, index) => (
-                <div key={index}>
-                    {content}
-                </div>
-            ))}
-        </div>
-    );
+	return (
+		<div>
+			<button type="button" onClick={handleSortToggle} {...props}>
+				{isDescending ? "Sort Descending" : "Sort Ascending"}
+			</button>
+			{renderedContent.map((content, index) => (
+				<div key={index}>{content}</div>
+			))}
+		</div>
+	);
 }
 
-const DocSorter = Island("doc", DocSorter_);
-export default DocSorter
+const DocSorter = Island(DocSorter_);
+export default DocSorter;

--- a/pages/index/Caller.tsx
+++ b/pages/index/Caller.tsx
@@ -21,6 +21,6 @@ export function Caller({ ...props }: PropsWithChildren) {
 	);
 }
 
-const CallerIsland = Island("Caller", Caller);
+const CallerIsland = Island(Caller);
 
 export default CallerIsland;

--- a/pages/index/index.page.tsx
+++ b/pages/index/index.page.tsx
@@ -9,8 +9,8 @@ import { ColorChanger } from "../about/Component";
 export { Page };
 export const PrefetchSetting = { mode: "hover" };
 
-const IslandCounter = Island("index", Counter);
-const IslandAccumulator = Island("index", Accumulator);
+const IslandCounter = Island(Counter);
+const IslandAccumulator = Island(Accumulator);
 
 function Page() {
 	return (

--- a/pages/test/MdxContentRenderer.tsx
+++ b/pages/test/MdxContentRenderer.tsx
@@ -1,42 +1,49 @@
 import React, { useState, useEffect } from "react";
 import { Island } from "@/arkhi/client";
-import { allFiles as allMdxFiles } from '../../content/*';
+import { allFiles as allMdxFiles } from "../../content/*";
 
 function MdxContentRenderer_({ ...props }) {
-    const [selectedTag, setSelectedTag] = useState("");
-    const [displayFiles, setDisplayFiles] = useState(allMdxFiles);
+	const [selectedTag, setSelectedTag] = useState("");
+	const [displayFiles, setDisplayFiles] = useState(allMdxFiles);
 
-    const allTags = [...new Set(allMdxFiles.flatMap(file => file.metadata.tags.flat()))];
+	const allTags = [
+		...new Set(allMdxFiles.flatMap((file) => file.metadata.tags.flat())),
+	];
 
-    useEffect(() => {
-        const updatedFiles = selectedTag
-            ? allMdxFiles.filter(file => {
-                const hasTag = file.metadata.tags.flat().includes(selectedTag);
-                return hasTag;
-            })
-            : allMdxFiles;
-        setDisplayFiles(updatedFiles);
-    }, [selectedTag]);
+	useEffect(() => {
+		const updatedFiles = selectedTag
+			? allMdxFiles.filter((file) => {
+					const hasTag = file.metadata.tags
+						.flat()
+						.includes(selectedTag);
+					return hasTag;
+			  })
+			: allMdxFiles;
+		setDisplayFiles(updatedFiles);
+	}, [selectedTag]);
 
-    return (
-        <div {...props}>
-            <label>Select Tag: </label>
-            <select value={selectedTag} onChange={(e) => setSelectedTag(e.target.value)} >
-                {allTags.map(tag => (
-                    <option key={tag} value={tag}>{tag}</option>
-                ))}
-            </select>
-            {displayFiles.map((file, index) => (
-                <div key={index} >
-                    <file.component />
-                    <div className="mdx-metadata">
-                    </div>
-                </div>
-            ))}
-        </div>
-    );
-
+	return (
+		<div {...props}>
+			<label>Select Tag: </label>
+			<select
+				value={selectedTag}
+				onChange={(e) => setSelectedTag(e.target.value)}
+			>
+				{allTags.map((tag) => (
+					<option key={tag} value={tag}>
+						{tag}
+					</option>
+				))}
+			</select>
+			{displayFiles.map((file, index) => (
+				<div key={index}>
+					<file.component />
+					<div className="mdx-metadata"></div>
+				</div>
+			))}
+		</div>
+	);
 }
 
-const MdxContentRenderer = Island("mdx", MdxContentRenderer_);
+const MdxContentRenderer = Island(MdxContentRenderer_);
 export default MdxContentRenderer;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { UserConfig } from "vite";
 const config: UserConfig = {
 	plugins: [react(), ssr(), tsconfigPaths(), arkhiPlugin()],
 	esbuild: {
-		minifyIdentifiers: false,
+		keepNames: true,
 	},
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,6 @@ import { UserConfig } from "vite";
 
 const config: UserConfig = {
 	plugins: [react(), ssr(), tsconfigPaths(), arkhiPlugin()],
-	esbuild: {
-		keepNames: true,
-	},
 };
 
 export default config;


### PR DESCRIPTION
Enabling keepname in esbuild to ensure clientside island id matches island namespace is renamed to prefix, and is now optional

Feature discorvered by @amyD0947639 